### PR TITLE
[Sean-Kurian/OnlyLs#4] Fix : Close gracefully if the client is not running

### DIFF
--- a/APIGetter.py
+++ b/APIGetter.py
@@ -7,7 +7,12 @@ from urllib.parse import urlencode
 
 class APIGetter: 
     def __init__(self): 
+        #declare and initialize the necessary fields
         self._league_client = 'LeagueClientUx.exe'
+        self._shell=None
+        self._lockfile=None
+        self._lcu_auth_token=None
+
         for proc in psutil.process_iter(): 
             if proc.name() == self._league_client: 
                 str = proc.exe()
@@ -20,6 +25,10 @@ class APIGetter:
                 with open(self._lockfile, 'r') as f:
                     file_data = f.read().split(':')
                     self._lcu_auth_token = base64.b64encode(('riot:' + file_data[3]).encode('ascii')).decode('ascii')
+        
+        #check if LoL is running: if not, quit the program
+        if self._shell==None:
+            exit("League of Legends should be running in order to use this tool.\nQUITTING!\n")
 
         for line in self._shell:
             if '--region=' in line:

--- a/main.py
+++ b/main.py
@@ -9,8 +9,6 @@ def main(page: flet.Page):
     page.window_minimizable = True
     page.window_maximizable = False
 
-    # TODO: Error checking if league client isn't open
-
     # Main Window Elements
     window = Window()
     page.add(window)


### PR DESCRIPTION
I've modified the code inside the class APIGetter: first of all I've declared and initialized all the fields to _None;_ the error that was popping out when the client wasn't running was due to the fact that a variable (_shell) has not been initialized. 
Clearly having a non-running client was causing problems also with initialized fields, so after the check on the running processes, if the _shell variable's values is still None, the program will exit explaining the problem.
At the moment I've used the following as quitting sentence:

> League of Legends should be running in order to use this tool.
QUITTING!

but you can modify it as you desire (APIGetter:31).
